### PR TITLE
vendor/styx: Move QTI BT namespaces to BoardConfigStyx

### DIFF
--- a/config/BoardConfigQcom.mk
+++ b/config/BoardConfigQcom.mk
@@ -97,9 +97,3 @@ PRODUCT_SOONG_NAMESPACES += \
 ifeq ($(TARGET_HW_DISK_ENCRYPTION),true)
     TARGET_CRYPTFS_HW_PATH ?= vendor/qcom/opensource/cryptfs_hw
 endif
-
-ifeq ($(TARGET_USE_QTI_BT_STACK),true)
-PRODUCT_SOONG_NAMESPACES += \
-    vendor/qcom/opensource/commonsys/packages/apps/Bluetooth \
-    vendor/qcom/opensource/commonsys/system/bt/conf
-endif #TARGET_USE_QTI_BT_STACK

--- a/config/BoardConfigStyx.mk
+++ b/config/BoardConfigStyx.mk
@@ -1,6 +1,15 @@
 # Kernel
 include vendor/styx/config/BoardConfigKernel.mk
 
+# Required for QTI BT Stack
+ifeq ($(TARGET_USE_QTI_BT_STACK),true)
+PRODUCT_SOONG_NAMESPACES += \
+    vendor/qcom/opensource/commonsys/packages/apps/Bluetooth \
+    vendor/qcom/opensource/commonsys/system/bt/conf
+else
+PRODUCT_SOONG_NAMESPACES += packages/apps/Bluetooth
+endif
+
 # Qcom-specific bits
 ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
 include vendor/styx/config/BoardConfigQcom.mk


### PR DESCRIPTION
- Devices not setting PRODUCT_USES_QCOM_HARDWARE to true fail to build
as Bluetooth namespace doesn't get added

Signed-off-by: SahilSonar <sss.sonar2003@gmail.com>