### PR TITLE
soong: introduce TARGET_INPUTDISPATCHER_SKIP_EVENT_KEY

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -467,3 +467,19 @@ stagefright_qcom_legacy {
         },
     },
 }
+soong_config_module_type {
+    name: "inputdispatcher_skip_event_key",
+    module_type: "cc_defaults",
+    config_namespace: "styxGlobalVars",
+    value_variables: ["target_inputdispatcher_skip_event_key"],
+    properties: ["cppflags"],
+}
+
+inputdispatcher_skip_event_key {
+    name: "inputdispatcher_skip_event_key_defaults",
+    soong_config_variables: {
+        target_inputdispatcher_skip_event_key: {
+            cppflags: ["-DINPUTDISPATCHER_SKIP_EVENT_KEY=%s"],
+        },
+    },
+}

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -35,6 +35,7 @@ SOONG_CONFIG_styxGlobalVars += \
     ignores_ftp_pptp_conntrack_failure \
     needs_netd_direct_connect_rule \
     target_init_vendor_lib \
+    target_inputdispatcher_skip_event_key \
     target_ld_shim_libs \
     target_process_sdk_version_override \
     target_surfaceflinger_fod_lib \
@@ -82,6 +83,7 @@ SOONG_CONFIG_styxQcomVars_legacy_hw_disk_encryption := $(TARGET_LEGACY_HW_DISK_E
 # Set default values
 BOOTLOADER_MESSAGE_OFFSET ?= 0
 TARGET_INIT_VENDOR_LIB ?= vendor_init
+TARGET_INPUTDISPATCHER_SKIP_EVENT_KEY ?= 0
 TARGET_SPECIFIC_CAMERA_PARAMETER_LIBRARY ?= libcamera_parameters
 TARGET_SURFACEFLINGER_FOD_LIB ?= surfaceflinger_fod_lib
 
@@ -93,6 +95,7 @@ SOONG_CONFIG_styxGlobalVars_target_ld_shim_libs := $(subst $(space),:,$(TARGET_L
 SOONG_CONFIG_styxGlobalVars_target_process_sdk_version_override := $(TARGET_PROCESS_SDK_VERSION_OVERRIDE)
 SOONG_CONFIG_styxGlobalVars_target_surfaceflinger_fod_lib := $(TARGET_SURFACEFLINGER_FOD_LIB)
 SOONG_CONFIG_styxGlobalVars_uses_camera_parameter_lib := $(TARGET_SPECIFIC_CAMERA_PARAMETER_LIBRARY)
+SOONG_CONFIG_styxGlobalVars_target_inputdispatcher_skip_event_key := $(TARGET_INPUTDISPATCHER_SKIP_EVENT_KEY)
 ifneq ($(filter $(UM_PLATFORMS),$(TARGET_BOARD_PLATFORM)),)
 SOONG_CONFIG_styxQcomVars_qcom_display_headers_namespace := vendor/qcom/opensource/commonsys-intf/display
 else


### PR DESCRIPTION
Set TARGET_INPUTDISPATCHER_SKIP_EVENT_KEY to the key code to skip in InputDispatcher

Fixes a lag in the UI when scrolling while holding the fingerprint sensor

Test : Open a webpage and scroll while having a finger on the fingerprint sensor

Signed-off-by: daniml3 <danimoral1001@gmail.com>
Change-Id: I682913c29bdb92409b05aea7dfa1bcfa3a74653f